### PR TITLE
Custom api calls

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -8,11 +8,20 @@
     <title>bigbluebutton-api-js example</title>
     <script type="text/javascript">
 
+      escapeHtml = function(unsafe) {
+        return unsafe
+             .replace(/&/g, "&amp;")
+             .replace(/</g, "&lt;")
+             .replace(/>/g, "&gt;")
+             .replace(/"/g, "&quot;")
+             .replace(/'/g, "&#039;");
+      }
+
       htmlFromResults = function(results) {
         var output = "<h4>Results:</h4>";
         for (property in results) {
           output += property + " = ";
-          output += "<a href='" + results[property] + "'>" + results[property] + "</a>";
+          output += "<a href='" + results[property] + "'>" + escapeHtml(results[property]) + "</a>";
           output += "<br>"
         }
         return output;
@@ -22,27 +31,39 @@
         server = $("#server").val();
         salt = $("#salt").val();
         mobileSalt = $("#mobile-salt").val();
+        meetingID = $("#meetingID").val();
         moderatorPW = $("#moderatorPW").val();
         attendeePW = $("#attendeePW").val();
-        customCalls = $("#customCalls").val().split(/\n/);
 
-        customParams = {}
-        var length = customCalls.length,
-        element = null;
-        for (var i = 0; i < length; i++) {
-          element = customCalls[i];
+        //for custom calls
+        splitCalls = $("#customCalls").val().split(/\n/);
+        customCalls = {};   
+        for (var i = 0; i < splitCalls.length; i++) {
+          var element = splitCalls[i];
           var keyvalue = element.split("=");
           var key = "call_" + keyvalue[0];
+          customCalls[key] = keyvalue[1];
+        }
+
+        //for custom calls
+        splitParams = $("#customParams").val().split(/\n/);
+        customParams = {}
+
+        for (var i = 0; i < splitParams.length; i++) {
+          var element = splitParams[i];
+          var keyvalue = element.split("=");
+          var key = "custom_" + keyvalue[0];
           customParams[key] = keyvalue[1];
         }
 
         api = new BigBlueButtonApi(server, salt, mobileSalt);
-        params = $.extend( { moderatorPW: moderatorPW, attendeePW: attendeePW } , customParams);
+        params = $.extend( { meetingID:meetingID, moderatorPW: moderatorPW, attendeePW: attendeePW } , customCalls, customParams);
         r = api.getUrls(params);
         $("#results").html(htmlFromResults(r));
       }
 
       $(document).ready(function() {
+        $("#meetingID").val("test-" + Math.floor(Math.random()*10000));
         $("#generate").on("click", function() {
           getAll();
         });
@@ -68,6 +89,10 @@
       </div>
       <h4>Some basic parameters:</h4>
       <div class="fieldset">
+        <label for="meetingID" class="control-label">Meeting ID:</label>
+        <input id="meetingID" type="text">
+      </div>
+      <div class="fieldset">
         <label for="moderatorPW" class="control-label">Moderator password:</label>
         <input id="moderatorPW" type="text" value="mp">
       </div>
@@ -75,10 +100,14 @@
         <label for="attendeePW" class="control-label">Attendee password:</label>
         <input id="attendeePW" type="text" value="ap">
       </div>
-      <h4>Custom API calls</h4>
+      <h4>Custom Fields</h4>
       <div class="fieldset">
         <label for="customCalls" class="control-label">Custom API calls:</label>
-        <textarea id="customCalls" placeHolder="attribute=value (one per line)" rows="3"></textarea>
+        <textarea id="customCalls" placeHolder="name=APICall (one per line)" rows="3"></textarea>
+      </div>
+      <div class="fieldset">
+        <label for="customParams" class="control-label">Custom Parameters:</label>
+        <textarea id="customParams" placeHolder="attribute=value (one per line)" rows="3"></textarea>
       </div>
       <div class="fieldset">
         <button id="generate" value="123" class="btn btn-success">Generate</button>

--- a/lib/bigbluebutton-api.js
+++ b/lib/bigbluebutton-api.js
@@ -31,6 +31,8 @@
           return [["recordID", true], ["publish", true]];
         case "deleteRecordings":
           return [["recordID", true]];
+        default:
+          return [["meetingID", true]];
       }
     };
 
@@ -84,7 +86,7 @@
       joinMod = this.urlFor("join", params);
       joinModMobile = this.replaceMobileProtocol(joinMod);
       console.log(params);
-      return ret = {
+      ret = {
         'create': this.urlFor("create", params),
         'join (as moderator)': joinMod,
         'join (as attendee)': joinAtt,
@@ -99,14 +101,22 @@
         'join from mobile (as attendee)': joinAttMobile,
         'mobile: getTimestamp': this.urlForMobileApi("getTimestamp", params),
         'mobile: getMeetings': this.urlForMobileApi("getMeetings", params),
-        'mobile: create': this.urlForMobileApi("create", params),
-        'customurl': this.urlForCustomApiCalls(params)
+        'mobile: create': this.urlForMobileApi("create", params)
       };
+      return ret = $.extend(ret, this.urlForCustomApiCalls(params));
     };
 
     BigBlueButtonApi.prototype.urlForCustomApiCalls = function(params) {
-      var ret;
-      return ret = "";
+      var custom_call, key, param, ret, urls;
+      urls = {};
+      for (key in params) {
+        param = params[key];
+        if (key.match(/^call_/)) {
+          custom_call = key.replace(/^call_/, "");
+          urls['custom call ' + custom_call + ':'] = this.urlFor(param, params);
+        }
+      }
+      return ret = urls;
     };
 
     BigBlueButtonApi.prototype.urlFor = function(method, params) {

--- a/src/bigbluebutton-api.coffee
+++ b/src/bigbluebutton-api.coffee
@@ -57,6 +57,8 @@ class BigBlueButtonApi
         ]
       when "deleteRecordings"
         [ [ "recordID", true ] ]
+      else 
+        [ [ "meetingID", true ] ]
 
   # Filter `params` to allow only parameters that can be passed
   # to the method `method`.
@@ -120,12 +122,17 @@ class BigBlueButtonApi
       'mobile: getMeetings': @urlForMobileApi("getMeetings", params)
       'mobile: create': @urlForMobileApi("create", params)
 
-      'customurl' : @urlForCustomApiCalls(params)
+    ret = $.extend(ret, @urlForCustomApiCalls(params))
 
   # Returns custom API calls
   urlForCustomApiCalls: (params) ->
-    ret =
-      ""
+    urls = {}
+    for key, param of params
+      if key.match(/^call_/) 
+        custom_call = key.replace(/^call_/, "")
+        urls[ 'custom call ' + custom_call + ':'] =  @urlFor(param, params)
+    
+    ret = urls
 
   # Returns a url for any `method` available in the BigBlueButton API
   # using the parameters in `params`.


### PR DESCRIPTION
Added: generate custom api calls urls and update the example page

Currently, by default is included the meetingID and custom parameters. However, we could think a better way to include other parameters.
