### PR TITLE
Escape !, ', (, ), and * characters when generating URLs.

### DIFF
--- a/lib/bigbluebutton-api.js
+++ b/lib/bigbluebutton-api.js
@@ -161,7 +161,9 @@
     };
 
     BigBlueButtonApi.prototype.encodeForUrl = function(value) {
-      return encodeURIComponent(value).replace(/%20/g, '+');
+      // encodeURIComponent doesn't escape !'()* but browsers do, so manually escape them.
+      // Use + instead of %20 for space to match what the Java tools do.
+      return encodeURIComponent(value).replace(/[!'()]/g, escape).replace(/\*/g, "%2A").replace(/%20/g, '+');
     };
 
     return BigBlueButtonApi;


### PR DESCRIPTION
If you attempt to open a URL that has these characters unescaped in a
browser, it may re-encode the URL to escape them. This breaks the
checksum.

To avoid the issue, just force these characters to always be escaped.

Fixes #2
